### PR TITLE
fix building with clang

### DIFF
--- a/cgit.h
+++ b/cgit.h
@@ -65,7 +65,7 @@ typedef enum {
 struct cgit_filter {
 	int (*open)(struct cgit_filter *, va_list ap);
 	int (*close)(struct cgit_filter *);
-	void (*fprintf)(struct cgit_filter *, FILE *, const char *prefix);
+	void (*fprintfp)(struct cgit_filter *, FILE *, const char *prefix);
 	void (*cleanup)(struct cgit_filter *);
 	int argument_count;
 };

--- a/filter.c
+++ b/filter.c
@@ -128,7 +128,7 @@ void cgit_exec_filter_init(struct cgit_exec_filter *filter, char *cmd, char **ar
 	memset(filter, 0, sizeof(*filter));
 	filter->base.open = open_exec_filter;
 	filter->base.close = close_exec_filter;
-	filter->base.fprintf = fprintf_exec_filter;
+	filter->base.fprintfp = fprintf_exec_filter;
 	filter->base.cleanup = cleanup_exec_filter;
 	filter->cmd = cmd;
 	filter->argv = argv;
@@ -353,7 +353,7 @@ static struct cgit_filter *new_lua_filter(const char *cmd, int argument_count)
 	memset(filter, 0, sizeof(*filter));
 	filter->base.open = open_lua_filter;
 	filter->base.close = close_lua_filter;
-	filter->base.fprintf = fprintf_lua_filter;
+	filter->base.fprintfp = fprintf_lua_filter;
 	filter->base.cleanup = cleanup_lua_filter;
 	filter->base.argument_count = argument_count;
 	filter->script_file = xstrdup(cmd);
@@ -385,7 +385,7 @@ int cgit_close_filter(struct cgit_filter *filter)
 
 void cgit_fprintf_filter(struct cgit_filter *filter, FILE *f, const char *prefix)
 {
-	filter->fprintf(filter, f, prefix);
+	filter->fprintfp(filter, f, prefix);
 }
 
 


### PR DESCRIPTION
fix error that is given because of macro overlapping `cgit_filter`'s member:

```
../filter.c:388:10: error: no member named '__fprintf_chk' in 'struct cgit_filter'
  388 |         filter->fprintf(filter, f, prefix);
      |         ~~~~~~  ^
/usr/include/bits/stdio2.h:92:3: note: expanded from macro 'fprintf'
   92 |   __fprintf_chk (stream, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
      |   ^
1 error generated.
```